### PR TITLE
Remove rubocop-rails_config dependency from config which we're not setting up

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -9,11 +9,6 @@ AllCops:
     - "config.ru"
     - "Rakefile"
 
-require: rubocop-rspec
-inherit_gem:
-  rubocop-rails_config:
-    - config/rails.yml
-
 Bundler/DuplicatedGem:
   Enabled: true
 


### PR DESCRIPTION
Fixed issue https://github.com/datarockets/datarockets-style/issues/11