### PR TITLE
[#56] Write empty methods in expanded way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## master (unreleased)
 
+### Changed
+
+* Allow writing empty methods in two lines ([@v.kuzmik][])
+
 ## 0.2.0 (2019-07-17)
 
 ### Changed
@@ -38,3 +42,4 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 [@r.dubrovsky]: https://github.com/roman-dubrovsky
 [@aleks]: https://github.com/AleksSenkou
 [@ula]: https://github.com/lazycoder9
+[@v.kuzmik]: https://github.com/TheBlackArroVV/

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -240,6 +240,26 @@ rescue MyException => error
   # do something
 end
 ```
+
+
+* <a name="style-empty-method"></a>
+  Write empty methods in an expanded way.
+  <sup>[[link](#empty-method)]</sup>
+
+```ruby
+# bad
+def foo(bar); end
+
+def self.foo(bar); end
+
+# good
+def foo(bar)
+end
+
+def self.foo(bar)
+end
+```
+
 ## Rspec
 
 * <a name="rspec-betterrspec"></a>

--- a/default.yml
+++ b/default.yml
@@ -47,5 +47,8 @@ Naming/RescuedExceptionsVariableName:
 RSpec/ImplicitSubject:
   Enabled: false
 
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyMethod
https://github.com/datarockets/datarockets-style/issues/56