### PR TITLE
[Fix #57] Disable Lint/AmbiguousBlockAssociation with Rspec syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 * Allow writing empty methods in two lines ([@v.kuzmik][])
 
+### Fixed
+
+* Disable `Lint/AmbiguousBlockAssociation` for Rspec directory. ([@r.dubrovsky][])
+
 ## 0.2.0 (2019-07-17)
 
 ### Changed

--- a/default.yml
+++ b/default.yml
@@ -34,6 +34,10 @@ Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
   EnforcedStyleForEmptyBraces: no_space
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"


### PR DESCRIPTION
See https://github.com/datarockets/datarockets-style/issues/57

