### PR TITLE
[#32] Disable magic comment cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 ### Changed
 
 * Allow writing empty methods in two lines. ([@v.kuzmik][])
+* Disable `Style/FrozenStringLiteralComment` cop by default. ([@r.dubrovsky][])
 
 ### Fixed
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -260,6 +260,12 @@ def self.foo(bar)
 end
 ```
 
+* <a name="style-magic-link"></a>
+  There are not any requried rules for `frozen_string_literal` magic url.
+  Set up [this cop](https://rubocop.readthedocs.io/en/latest/cops_style/#stylefrozenstringliteralcomment) depends  on the project.
+  So set up it on the local rubocop config manually.
+  <sup>[[link](#style-magic-link)]</sup>
+
 ## Rspec
 
 * <a name="rspec-betterrspec"></a>

--- a/default.yml
+++ b/default.yml
@@ -55,5 +55,8 @@ RSpec/ImplicitSubject:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
This PR temporary resolve issue #32 (so it does not have `Fix` label). see https://github.com/datarockets/datarockets-style/issues/32#issuecomment-514613328

So this PR just disable this cop for now. 

Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [x] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
