### PR TITLE
Add style for curly braces around hash params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## master (unreleased)
 
+### Changed
+
+* Use contenxt-dependent style for curly braces around hash params. ([@v.kuzmik][])
+
 ## 0.3.0 (2019-08-02)
 
 ### Changed

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -272,6 +272,21 @@ end
   So set up it on the local rubocop config manually.
   <sup>[[link](#style-magic-link)]</sup>
 
+* <a name="style-braces-around-hash-params"></a>
+  Not to use braces around the last hash literal parameter.
+  But requires braces if the second to last parameter is also a hash literal.
+  <sup>[[link](#style-braces-around-hash-params)]</sup>
+
+```ruby
+# bad
+some_method(x, y, {a: 1, b: 2})
+some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
+
+# good
+some_method(x, y, a: 1, b: 2)
+some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
+```
+
 ## Rspec
 
 * <a name="rspec-betterrspec"></a>

--- a/config/default.yml
+++ b/config/default.yml
@@ -52,6 +52,9 @@ Naming/RescuedExceptionsVariableName:
 RSpec/ImplicitSubject:
   Enabled: false
 
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
 


### PR DESCRIPTION
https://github.com/datarockets/datarockets-style/issues/73
https://rubocop.readthedocs.io/en/latest/cops_style/#stylebracesaroundhashparameters