### PR TITLE
Remove bundler as local dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
   datarockets-style!
   rake (~> 13.0)
 

--- a/datarockets-style.gemspec
+++ b/datarockets-style.gemspec
@@ -33,6 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop", "~> 0.74.0"
   spec.add_dependency "rubocop-rspec", "~> 1.35"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
Before you submit a pull request, please make sure you have to follow:

 I remove `bundler` as a local dependency cause usually we install it into the home directory. @dzhlobo @AleksSenkou  How do you think:  is it a good idea?  
