### PR TITLE
[Fix #96] Setup RSpec/ExpectChange cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 * Update rubocop to `0.75.0`.
 * Update rubocop-rspec to `1.36.0`.
+* Use block style for `RSpec/ExpectChange` cop. ([@r.dubrovsky][])
 
 ### Fixed
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -427,3 +427,15 @@ context "when the display name is not present" do
   # ...
 end
 ```
+
+* <a name="rspec-expect-change"></a>
+  Prefer using blocks for change matcher than method calls.
+  <sup>[[link](#rspec-expect-change)]</sup>
+
+```ruby
+# bad
+expect { run }.to change(Foo, :bar)
+
+# good
+expect { run }.to change { Foo.bar }
+```

--- a/config/default.yml
+++ b/config/default.yml
@@ -68,6 +68,9 @@ RSpec/ContextWording:
     - without
     - for
 
+RSpec/ExpectChange:
+  EnforcedStyle: block
+
 RSpec/ImplicitSubject:
   Enabled: false
 


### PR DESCRIPTION
Change style for `RSpec/ExpectChange` cop to `block`. 

Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [x] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
