### PR TITLE
[Fix #113] Update RuboCop version to 0.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ### Changed
 
+* Update rubocop to `0.76`. ([@r.dubrovsky][])
 * Added `RSpec/ExampleLength` cop to style guide. ([@a.branzeanu][])
 
 ## 0.5.0 (2019-10-26)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ PATH
   remote: .
   specs:
     datarockets-style (0.5.0)
-      rubocop (>= 0.74, < 0.76)
+      rubocop (~> 0.76)
       rubocop-rspec (~> 1.36)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (13.0.0)
-    rubocop (0.75.1)
+    rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)

--- a/datarockets-style.gemspec
+++ b/datarockets-style.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.74", "< 0.76"
+  spec.add_dependency "rubocop", "~> 0.76"
   spec.add_dependency "rubocop-rspec", "~> 1.36"
 
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Release Notes: https://github.com/rubocop-hq/rubocop/releases/tag/v0.76.0