### PR TITLE
[Fix #80] Added inherit_mode in .rubocop.yml in order to extend Excludes not override

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,9 @@ inherit_from:
   - config/ruby.yml
   - config/rspec.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   TargetRubyVersion: 2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## master (unreleased)
 
+## Fixed
+
+* [#80](https://github.com/datarockets/datarockets-style/issues/80): Allows adds additional files and directories to excluding block for rubocop. ([@nikitasakov][])
 
 ## 0.6.2 (2019-12-05)
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -24,7 +24,7 @@ Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:
-    EnforcedStyle: indented
+  EnforcedStyle: indented
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space


### PR DESCRIPTION
### Basic checklist
Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [x] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review

### Description of the problem
The problem is that when we add exclude in rubocop.yml file it overrides exclude inherited from config/ruby.yml and config/rspec.yml.

### Solution
Found how not to override Excludes but extend - `inherit_mode`

### How I tested that it works:

1. Create file with style mistake. Run rubocop and see offense.
![image](https://user-images.githubusercontent.com/32716983/71992323-42eab900-3246-11ea-81ad-f9020043d319.png)

2. Add this code to rubocop.yml in order to exclude our file with mistake:

`# .rubocop.yml`
```
AllCops:
  TargetRubyVersion: 2.3
  Exclude:
    - "test.rb"
```
Run rubocop again and see that our new file excluded because we don't see offense in it anymore. **But** we see offense in other file. 
![image](https://user-images.githubusercontent.com/32716983/71992589-a83eaa00-3246-11ea-8bf7-236ea410b44f.png)
Our Exclude has overridden current Exclude. That's why we got offense in file - it is not Excluded anymore.

3. Add this code in order to merge new Exclude and old one so it is not overrode it is extended.

`# .rubocop.yml`
```
inherit_mode:
  merge:
    - Exclude
```
Run rubocop again.
![image](https://user-images.githubusercontent.com/32716983/71992952-56e2ea80-3247-11ea-87c2-23166e2f451b.png)
**no offenses**
Now all files Excluded in one time. Our Exclude section is not overrode.

### My questions 

1. I've added `inherit_mode` in rubocop.yml only because I am not sure should we have this behavior everywhere or not. We can add it to ruby.yml, rails.yml and those files will also extend Excludes from base.yml. Thoughts?
2. I see that `inherit_from` in rubocop.yml placed before `AllCops`. Should we change order in order to have alphabet order? Is it about `verified that cops are ordered by alphabet` or `inherit_from` and `inherit_mode` are not cops and we can leave it as it is?
