### PR TITLE
[Fix #130] Layout/ArrayAlignment extended so now you can use with_fixed_indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 * [#80](https://github.com/datarockets/datarockets-style/issues/80): Allows adds additional files and directories to excluding block for rubocop. ([@nikitasakov][])
 
+### Added
+
+* [#130](https://github.com/datarockets/datarockets-style/issues/130): Layout/ArrayAlignmentExtended cop ([@nikitasakov][])
+
 ## 0.6.2 (2019-12-05)
 
 ### Changed

--- a/config/base.yml
+++ b/config/base.yml
@@ -1,3 +1,5 @@
+require: datarockets/style
+
 Bundler/DuplicatedGem:
   Enabled: true
 
@@ -6,6 +8,35 @@ Bundler/OrderedGems:
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
+
+Layout/ArrayAlignment:
+  Enabled: false
+
+Layout/ArrayAlignmentExtended:
+  Description: >-
+                 Align the elements of an array literal if they span more than
+                 one line.
+  # Alignment of elements of a multi-line array.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first element.
+  #
+  #     array = [1, 2, 3,
+  #              4, 5, 6]
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with start of array.
+  #
+  #     array = [1, 2, 3,
+  #       4, 5, 6]
+  EnforcedStyle: with_fixed_indentation
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: always_ignore

--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -151,6 +151,27 @@ def foo(
 end
 ```
 
+* <a name="style-array-aligning"></a>
+  The elements of a multi-line array are aligning by an indentation level.
+  <sup>[[link](#style-array-aligning)]</sup>
+
+```ruby
+# bad
+
+array = [1, 2, 3,
+         4, 5, 6]
+
+# bad
+
+array = [1, 2, 3,
+      4, 5, 6]
+
+# good
+
+array = [1, 2, 3,
+  4, 5, 6]
+```
+
 * <a name="style-multiline-method-call-indentation"></a>
   The indentation of the method name part in method calls that span more than one line are aligning by an indentation level.
   <sup>[[link](#style-multiline-method-call-indentation)]</sup>

--- a/lib/datarockets/style.rb
+++ b/lib/datarockets/style.rb
@@ -3,6 +3,8 @@ require "datarockets/style/formatter/todo_list_formatter"
 
 require "datarockets/style/version"
 
+require "datarockets/style/cop/layout/array_alignment_extended"
+
 module Datarockets
   # Datarickors sharable config
   module Style

--- a/lib/datarockets/style/cop/layout/array_alignment_extended.rb
+++ b/lib/datarockets/style/cop/layout/array_alignment_extended.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Datarockets
+  module Style
+    module Cop
+      module Layout
+        # Here we check if the elements of a multi-line array literal are
+        # aligned.
+        #
+        # @example EnforcedStyle: with_first_argument (default)
+        #   # good
+        #
+        #   array = [1, 2, 3,
+        #            4, 5, 6]
+        #   array = ['run',
+        #            'forrest',
+        #            'run']
+        #
+        #   # bad
+        #
+        #   array = [1, 2, 3,
+        #     4, 5, 6]
+        #   array = ['run',
+        #        'forrest',
+        #        'run']
+        #
+        # @example EnforcedStyle: with_fixed_indentation
+        #   # good
+        #
+        #   array = [1, 2, 3,
+        #     4, 5, 6]
+        #
+        #   # bad
+        #
+        #   array = [1, 2, 3,
+        #            4, 5, 6]
+        class ArrayAlignmentExtended < RuboCop::Cop::Cop
+          include RuboCop::Cop::Alignment
+
+          ALIGN_PARAMS_MSG = "Align the elements of an array literal if they span more " \
+            "than one line."
+
+          FIXED_INDENT_MSG = "Use one level of indentation for elements " \
+            "following the first line of a multi-line array."
+
+          def on_array(node)
+            return if node.children.size < 2
+
+            check_alignment(node.children, base_column(node, node.children))
+          end
+
+          def autocorrect(node)
+            RuboCop::Cop::AlignmentCorrector.correct(processed_source, node, column_delta)
+          end
+
+          private
+
+          def message(_node)
+            fixed_indentation? ? FIXED_INDENT_MSG : ALIGN_PARAMS_MSG
+          end
+
+          def fixed_indentation?
+            cop_config["EnforcedStyle"] == "with_fixed_indentation"
+          end
+
+          def base_column(node, args)
+            if fixed_indentation?
+              lineno = target_method_lineno(node)
+              line = node.source_range.source_buffer.source_line(lineno)
+              indentation_of_line = /\S.*/.match(line).begin(0)
+              indentation_of_line + configured_indentation_width
+            else
+              display_column(args.first.source_range)
+            end
+          end
+
+          def target_method_lineno(node)
+            node.loc.line
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datarockets/style/cop/layout/array_alignment_extended_spec.rb
+++ b/spec/datarockets/style/cop/layout/array_alignment_extended_spec.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/ExampleLength
+
+RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new("Layout/ArrayAlignmentExtended" => cop_config,
+                        "Layout/IndentationWidth" => {
+                          "Width" => indentation_width
+                        })
+  end
+  let(:indentation_width) { 2 }
+
+  context "when aligned with first parameter" do
+    let(:cop_config) do
+      {
+        "EnforcedStyle" => "with_first_parameter"
+      }
+    end
+
+    it "registers an offense and corrects misaligned array elements" do
+      expect_offense(<<~RUBY)
+        array = [a,
+           b,
+           ^ Align the elements of an array literal if they span more than one line.
+          c,
+          ^ Align the elements of an array literal if they span more than one line.
+           d]
+           ^ Align the elements of an array literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array = [a,
+                 b,
+                 c,
+                 d]
+      RUBY
+    end
+
+    it "accepts aligned array keys" do
+      expect_no_offenses(<<~RUBY)
+        array = [a,
+                 b,
+                 c,
+                 d]
+      RUBY
+    end
+
+    it "accepts single line array" do
+      expect_no_offenses("array = [ a, b ]")
+    end
+
+    it "accepts several elements per line" do
+      expect_no_offenses(<<~RUBY)
+        array = [ a, b,
+                  c, d ]
+      RUBY
+    end
+
+    it "accepts aligned array with fullwidth characters" do
+      expect_no_offenses(<<~RUBY)
+        puts 'Ｒｕｂｙ', [ a,
+                           b ]
+      RUBY
+    end
+
+    it "does not auto-correct array within array with too much indentation" do
+      expect_offense(<<~RUBY)
+        [:l1,
+          [:l2,
+          ^^^^^ Align the elements of an array literal if they span more than one line.
+            [:l3,
+            ^^^^^ Align the elements of an array literal if they span more than one line.
+             [:l4]]]]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:l1,
+         [:l2,
+           [:l3,
+            [:l4]]]]
+      RUBY
+    end
+
+    it "does not auto-correct array within array with too little indentation" do
+      expect_offense(<<~RUBY)
+        [:l1,
+        [:l2,
+        ^^^^^ Align the elements of an array literal if they span more than one line.
+          [:l3,
+          ^^^^^ Align the elements of an array literal if they span more than one line.
+           [:l4]]]]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:l1,
+         [:l2,
+           [:l3,
+            [:l4]]]]
+      RUBY
+    end
+
+    it "does not indent heredoc strings in autocorrect" do
+      expect_offense(<<~RUBY)
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+              { :type => 'something',
+              ^^^^^^^^^^^^^^^^^^^^^^^ Align the elements of an array literal if they span more than one line.
+                :sql => <<EOF
+        Select something
+        from atable
+        EOF
+              }
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               }
+        ]
+      RUBY
+    end
+
+    it "accepts the first element being on a new row" do
+      expect_no_offenses(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
+
+    it "registers an offense and corrects misaligned array elements if the first element being on a new row" do
+      expect_offense(<<~RUBY)
+        array = [
+          a,
+           b,
+           ^ Align the elements of an array literal if they span more than one line.
+          c,
+           d
+           ^ Align the elements of an array literal if they span more than one line.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
+  end
+
+  context "when aligned with fixed indentation" do
+    let(:cop_config) do
+      {
+        "EnforcedStyle" => "with_fixed_indentation"
+      }
+    end
+
+    it "registers an offense and corrects misaligned array elements" do
+      expect_offense(<<~RUBY)
+        array = [a,
+           b,
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+          c,
+           d]
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array = [a,
+          b,
+          c,
+          d]
+      RUBY
+    end
+
+    it "accepts aligned array keys" do
+      expect_no_offenses(<<~RUBY)
+        array = [a,
+          b,
+          c,
+          d]
+      RUBY
+    end
+
+    it "accepts single line array" do
+      expect_no_offenses("array = [ a, b ]")
+    end
+
+    it "accepts several elements per line" do
+      expect_no_offenses(<<~RUBY)
+        array = [ a, b,
+          c, d ]
+      RUBY
+    end
+
+    it "accepts aligned array with fullwidth characters" do
+      expect_no_offenses(<<~RUBY)
+        puts 'Ｒｕｂｙ', [ a,
+          b ]
+      RUBY
+    end
+
+    it "does not auto-correct array within array with too much indentation" do
+      expect_offense(<<~RUBY)
+        [:l1,
+           [:l2,
+           ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+              [:l3,
+              ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+                [:l4]]]]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:l1,
+          [:l2,
+             [:l3,
+               [:l4]]]]
+      RUBY
+    end
+
+    it "does not auto-correct array within array with too little indentation" do
+      expect_offense(<<~RUBY)
+        [:l1,
+         [:l2,
+         ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+          [:l3,
+          ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+            [:l4]]]]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:l1,
+          [:l2,
+           [:l3,
+             [:l4]]]]
+      RUBY
+    end
+
+    it "does not indent heredoc strings in autocorrect" do
+      expect_offense(<<~RUBY)
+        var = [
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          },
+         { :type => 'something',
+         ^^^^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+           :sql => <<EOF
+        Select something
+        from atable
+        EOF
+         }
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = [
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          },
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          }
+        ]
+      RUBY
+    end
+
+    it "accepts the first element being on a new row" do
+      expect_no_offenses(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
+
+    it "registers an offense and corrects misaligned array elements if the first element being on a new row" do
+      expect_offense(<<~RUBY)
+        array = [
+          a,
+           b,
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+          c,
+           d
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
+  end
+end
+
+# rubocop:enable RSpec/ExampleLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 require "datarockets/style"
+require "rubocop/rspec/support"
 require "pry"
 
 RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+
   config.disable_monkey_patching!
   config.order = :random
   Kernel.srand config.seed


### PR DESCRIPTION
### Basic checklist
Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [x] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review

### Description of the problem

We want to write arrays this way:
```ruby
method_object %i[steps_data! start_step! checks_data! actions_data! waits_data! notes_data!
    connections_data! timezone! workflow!]
```
But rubocop doesn't support this style. It forces to write this way:
```ruby
method_object %i[steps_data! start_step! checks_data! actions_data! waits_data! notes_data!
                 connections_data! timezone! workflow!]
```
We could only disable this rule.
How it looks:
```yml
Layout/ArrayAlignment:
  Description: >-
                 Align the elements of an array literal if they span more than
                 one line.
  StyleGuide: '#align-multiline-arrays'
  Enabled: true
  VersionAdded: '0.49'
  VersionChanged: '0.77'

```
So I decided to write custom `Layout/ArrayAlignment` - `Layout/ArrayAlignmentExtended`. So now you can specify `with_fixed_indentation` flag. Decided not to monkey patch original `Layout/ArrayAlignment` in order not to cause problems in the future.

Used as patterns these cops in order to have more chances to be merged to the main rubocop:

https://github.com/rubocop-hq/rubocop/blob/ddb1ba77c7947e04a226fe57ae7789c2eca7a74b/lib/rubocop/cop/layout/parameter_alignment.rb

https://github.com/rubocop-hq/rubocop/blob/ddb1ba77c7947e04a226fe57ae7789c2eca7a74b/lib/rubocop/cop/layout/argument_alignment.rb
