### PR TITLE
Refactored Layout/ArrayAlignmentExtended

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ P.S. The string literals in this gem are using double quotes by default.
 
 For an existing project, we suggest running rubocop with both styles and choose which has fewer offenses (which is more popular in the current project).
 
+### Custom cops
+
+We have custom cops. You can find specification for them [here](manual).
+
 ## Formatters
 
 ### ToDo list formatter

--- a/config/base.yml
+++ b/config/base.yml
@@ -16,25 +16,10 @@ Layout/ArrayAlignmentExtended:
   Description: >-
                  Align the elements of an array literal if they span more than
                  one line.
-  # Alignment of elements of a multi-line array.
-  #
-  # The `with_first_parameter` style aligns the following lines along the same
-  # column as the first element.
-  #
-  #     array = [1, 2, 3,
-  #              4, 5, 6]
-  #
-  # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with start of array.
-  #
-  #     array = [1, 2, 3,
-  #       4, 5, 6]
   EnforcedStyle: with_fixed_indentation
   SupportedStyles:
     - with_first_parameter
     - with_fixed_indentation
-  # By default, the indentation width from Layout/IndentationWidth is used
-  # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
 

--- a/lib/datarockets/style/cop/layout/array_alignment_extended.rb
+++ b/lib/datarockets/style/cop/layout/array_alignment_extended.rb
@@ -64,14 +64,14 @@ module Datarockets
           end
 
           def base_column(node, args)
-            if fixed_indentation?
-              lineno = target_method_lineno(node)
-              line = node.source_range.source_buffer.source_line(lineno)
-              indentation_of_line = /\S.*/.match(line).begin(0)
-              indentation_of_line + configured_indentation_width
-            else
-              display_column(args.first.source_range)
-            end
+            fixed_indentation? ? line_indentation(node) : display_column(args.first.source_range)
+          end
+
+          def line_indentation(node)
+            lineno = target_method_lineno(node)
+            line = node.source_range.source_buffer.source_line(lineno)
+            line_indentation = /\S.*/.match(line).begin(0)
+            line_indentation + configured_indentation_width
           end
 
           def target_method_lineno(node)

--- a/lib/datarockets/style/cop/layout/array_alignment_extended.rb
+++ b/lib/datarockets/style/cop/layout/array_alignment_extended.rb
@@ -37,8 +37,7 @@ module Datarockets
         class ArrayAlignmentExtended < RuboCop::Cop::Cop
           include RuboCop::Cop::Alignment
 
-          ALIGN_PARAMS_MSG = "Align the elements of an array literal if they span more " \
-            "than one line."
+          ALIGN_PARAMS_MSG = "Align the elements of an array literal if they span more than one line."
 
           FIXED_INDENT_MSG = "Use one level of indentation for elements " \
             "following the first line of a multi-line array."

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1,0 +1,53 @@
+# Layout
+
+## Layout/ArrayAlignmentExtended
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.7.0 | -
+
+Here we check if the elements of a multi-line array literal are
+aligned.
+
+### Examples
+
+#### EnforcedStyle: with_fixed_indentation (default)
+
+```ruby
+# good
+
+array = [1, 2, 3,
+  4, 5, 6]
+
+# bad
+
+array = [1, 2, 3,
+         4, 5, 6]
+```
+
+#### EnforcedStyle: with_first_argument
+
+```ruby
+# good
+
+array = [1, 2, 3,
+         4, 5, 6]
+array = ['run',
+         'forrest',
+         'run']
+
+# bad
+
+array = [1, 2, 3,
+  4, 5, 6]
+array = ['run',
+     'forrest',
+     'run']
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `with_first_parameter` | `with_first_parameter`, `with_fixed_indentation`
+IndentationWidth | `<none>` | Integer

--- a/spec/datarockets/style/cop/layout/array_alignment_extended_spec.rb
+++ b/spec/datarockets/style/cop/layout/array_alignment_extended_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/ExampleLength
-
 RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
   subject(:cop) { described_class.new(config) }
 
@@ -11,7 +9,19 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
                           "Width" => indentation_width
                         })
   end
+
   let(:indentation_width) { 2 }
+
+  let(:aligned_array_with_first_element_on_new_line) do
+    <<~RUBY
+      array = [
+        a,
+        b,
+        c,
+        d
+      ]
+    RUBY
+  end
 
   context "when aligned with first parameter" do
     let(:cop_config) do
@@ -20,8 +30,8 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
       }
     end
 
-    it "registers an offense and corrects misaligned array elements" do
-      expect_offense(<<~RUBY)
+    let(:not_aligned_array) do
+      <<~RUBY
         array = [a,
            b,
            ^ Align the elements of an array literal if they span more than one line.
@@ -30,8 +40,10 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
            d]
            ^ Align the elements of an array literal if they span more than one line.
       RUBY
+    end
 
-      expect_correction(<<~RUBY)
+    let(:aligned_array) do
+      <<~RUBY
         array = [a,
                  b,
                  c,
@@ -39,13 +51,75 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
       RUBY
     end
 
-    it "accepts aligned array keys" do
-      expect_no_offenses(<<~RUBY)
-        array = [a,
-                 b,
-                 c,
-                 d]
+    let(:not_aligned_array_within_array_with_wrong_indentation) do
+      <<~RUBY
+        [:l1,
+         [:l2,
+           [:l3,
+            [:l4]]]]
       RUBY
+    end
+
+    let(:not_aligned_array_with_not_aligned_heredoc_strings) do
+      <<~RUBY
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+              { :type => 'something',
+              ^^^^^^^^^^^^^^^^^^^^^^^ Align the elements of an array literal if they span more than one line.
+                :sql => <<EOF
+        Select something
+        from atable
+        EOF
+              }
+        ]
+      RUBY
+    end
+
+    let(:aligned_array_with_not_aligned_heredoc_strings) do
+      <<~RUBY
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               }
+        ]
+      RUBY
+    end
+
+    let(:not_aligned_array_with_first_element_on_new_line) do
+      <<~RUBY
+        array = [
+          a,
+           b,
+           ^ Align the elements of an array literal if they span more than one line.
+          c,
+           d
+           ^ Align the elements of an array literal if they span more than one line.
+        ]
+      RUBY
+    end
+
+    it "registers an offense and corrects misaligned array elements" do
+      expect_offense(not_aligned_array)
+
+      expect_correction(aligned_array)
+    end
+
+    it "accepts aligned array keys" do
+      expect_no_offenses(aligned_array)
     end
 
     it "accepts single line array" do
@@ -76,12 +150,7 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
              [:l4]]]]
       RUBY
 
-      expect_correction(<<~RUBY)
-        [:l1,
-         [:l2,
-           [:l3,
-            [:l4]]]]
-      RUBY
+      expect_correction(not_aligned_array_within_array_with_wrong_indentation)
     end
 
     it "does not auto-correct array within array with too little indentation" do
@@ -94,82 +163,23 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
            [:l4]]]]
       RUBY
 
-      expect_correction(<<~RUBY)
-        [:l1,
-         [:l2,
-           [:l3,
-            [:l4]]]]
-      RUBY
+      expect_correction(not_aligned_array_within_array_with_wrong_indentation)
     end
 
     it "does not indent heredoc strings in autocorrect" do
-      expect_offense(<<~RUBY)
-        var = [
-               { :type => 'something',
-                 :sql => <<EOF
-        Select something
-        from atable
-        EOF
-               },
-              { :type => 'something',
-              ^^^^^^^^^^^^^^^^^^^^^^^ Align the elements of an array literal if they span more than one line.
-                :sql => <<EOF
-        Select something
-        from atable
-        EOF
-              }
-        ]
-      RUBY
+      expect_offense(not_aligned_array_with_not_aligned_heredoc_strings)
 
-      expect_correction(<<~RUBY)
-        var = [
-               { :type => 'something',
-                 :sql => <<EOF
-        Select something
-        from atable
-        EOF
-               },
-               { :type => 'something',
-                 :sql => <<EOF
-        Select something
-        from atable
-        EOF
-               }
-        ]
-      RUBY
+      expect_correction(aligned_array_with_not_aligned_heredoc_strings)
     end
 
     it "accepts the first element being on a new row" do
-      expect_no_offenses(<<~RUBY)
-        array = [
-          a,
-          b,
-          c,
-          d
-        ]
-      RUBY
+      expect_no_offenses(aligned_array_with_first_element_on_new_line)
     end
 
     it "registers an offense and corrects misaligned array elements if the first element being on a new row" do
-      expect_offense(<<~RUBY)
-        array = [
-          a,
-           b,
-           ^ Align the elements of an array literal if they span more than one line.
-          c,
-           d
-           ^ Align the elements of an array literal if they span more than one line.
-        ]
-      RUBY
+      expect_offense(not_aligned_array_with_first_element_on_new_line)
 
-      expect_correction(<<~RUBY)
-        array = [
-          a,
-          b,
-          c,
-          d
-        ]
-      RUBY
+      expect_correction(aligned_array_with_first_element_on_new_line)
     end
   end
 
@@ -180,8 +190,8 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
       }
     end
 
-    it "registers an offense and corrects misaligned array elements" do
-      expect_offense(<<~RUBY)
+    let(:not_aligned_array) do
+      <<~RUBY
         array = [a,
            b,
            ^ Use one level of indentation for elements following the first line of a multi-line array.
@@ -189,8 +199,10 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
            d]
            ^ Use one level of indentation for elements following the first line of a multi-line array.
       RUBY
+    end
 
-      expect_correction(<<~RUBY)
+    let(:aligned_array) do
+      <<~RUBY
         array = [a,
           b,
           c,
@@ -198,13 +210,75 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
       RUBY
     end
 
-    it "accepts aligned array keys" do
-      expect_no_offenses(<<~RUBY)
-        array = [a,
-          b,
-          c,
-          d]
+    let(:not_aligned_array_within_array_with_wrong_indentation) do
+      <<~RUBY
+        [:l1,
+          [:l2,
+             [:l3,
+               [:l4]]]]
       RUBY
+    end
+
+    let(:not_aligned_array_with_not_aligned_heredoc_strings) do
+      <<~RUBY
+        var = [
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          },
+         { :type => 'something',
+         ^^^^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+           :sql => <<EOF
+        Select something
+        from atable
+        EOF
+         }
+        ]
+      RUBY
+    end
+
+    let(:aligned_array_with_not_aligned_heredoc_strings) do
+      <<~RUBY
+        var = [
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          },
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          }
+        ]
+      RUBY
+    end
+
+    let(:not_aligned_array_with_first_element_on_new_line) do
+      <<~RUBY
+        array = [
+          a,
+           b,
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+          c,
+           d
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+        ]
+      RUBY
+    end
+
+    it "registers an offense and corrects misaligned array elements" do
+      expect_offense(not_aligned_array)
+
+      expect_correction(aligned_array)
+    end
+
+    it "accepts aligned array keys" do
+      expect_no_offenses(aligned_array)
     end
 
     it "accepts single line array" do
@@ -235,12 +309,7 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
                 [:l4]]]]
       RUBY
 
-      expect_correction(<<~RUBY)
-        [:l1,
-          [:l2,
-             [:l3,
-               [:l4]]]]
-      RUBY
+      expect_correction(not_aligned_array_within_array_with_wrong_indentation)
     end
 
     it "does not auto-correct array within array with too little indentation" do
@@ -248,89 +317,28 @@ RSpec.describe Datarockets::Style::Cop::Layout::ArrayAlignmentExtended do
         [:l1,
          [:l2,
          ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
-          [:l3,
-          ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
-            [:l4]]]]
+            [:l3,
+            ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+              [:l4]]]]
       RUBY
 
-      expect_correction(<<~RUBY)
-        [:l1,
-          [:l2,
-           [:l3,
-             [:l4]]]]
-      RUBY
+      expect_correction(not_aligned_array_within_array_with_wrong_indentation)
     end
 
     it "does not indent heredoc strings in autocorrect" do
-      expect_offense(<<~RUBY)
-        var = [
-          { :type => 'something',
-            :sql => <<EOF
-        Select something
-        from atable
-        EOF
-          },
-         { :type => 'something',
-         ^^^^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
-           :sql => <<EOF
-        Select something
-        from atable
-        EOF
-         }
-        ]
-      RUBY
+      expect_offense(not_aligned_array_with_not_aligned_heredoc_strings)
 
-      expect_correction(<<~RUBY)
-        var = [
-          { :type => 'something',
-            :sql => <<EOF
-        Select something
-        from atable
-        EOF
-          },
-          { :type => 'something',
-            :sql => <<EOF
-        Select something
-        from atable
-        EOF
-          }
-        ]
-      RUBY
+      expect_correction(aligned_array_with_not_aligned_heredoc_strings)
     end
 
     it "accepts the first element being on a new row" do
-      expect_no_offenses(<<~RUBY)
-        array = [
-          a,
-          b,
-          c,
-          d
-        ]
-      RUBY
+      expect_no_offenses(aligned_array_with_first_element_on_new_line)
     end
 
     it "registers an offense and corrects misaligned array elements if the first element being on a new row" do
-      expect_offense(<<~RUBY)
-        array = [
-          a,
-           b,
-           ^ Use one level of indentation for elements following the first line of a multi-line array.
-          c,
-           d
-           ^ Use one level of indentation for elements following the first line of a multi-line array.
-        ]
-      RUBY
+      expect_offense(not_aligned_array_with_first_element_on_new_line)
 
-      expect_correction(<<~RUBY)
-        array = [
-          a,
-          b,
-          c,
-          d
-        ]
-      RUBY
+      expect_correction(aligned_array_with_first_element_on_new_line)
     end
   end
 end
-
-# rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
Here are fixes after Roma's review of [this PR](https://github.com/datarockets/datarockets-style/pull/151)
## Changed
- Refactored base_column method of ArrayAlignmentExtended class in order to split it.
- Used variables in specs in order not to disable linter on them
- Removed comments in config because they are useless
- Created /manual folder in order to store docs there

## Basic checklist
Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [ ] add a note to the style guide docs (if it needs)
- [ ] add a note to the changelog file
- [ ] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
