### PR TITLE
Update rubocop version to 0.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ### Changed
 
-* Update rubocop to `0.87.1`. ([@r.dubrovsky][])
+* Update rubocop to `0.88.0`. ([@r.dubrovsky][])
   * Enable new cops `Lint/MixedRegexpCaptureTypes`, `Style/RedundantRegexpCharacterClass` and `Style/RedundantRegexpEscape`. Cops were added in version `0.85`.
   * Enable new cop `Style/RedundantFetchBlock`. Cop was added in version `0.86`.
   * Enable new cops `Style/AccessorGrouping`, `Style/BisectedAttrAccessor` and `Style/RedundantAssignment`. Cops were added in version `0.87`.
+  * Enable new cops `Lint/DuplicateElsifCondition`, `Style/ArrayCoercion`, `Style/CaseLikeIf`, `Style/HashAsLastArrayItem`, `Style/HashLikeCase` and `Style/RedundantFileExtensionInRequire`. Cops were added in version `0.88`.
 * Update rubocop-rails to `2.6.0`.
 * Update rubocop-rspec to `1.42.0`.
+
+* Setup `no_braces` rule for `Style/HashAsLastArrayItem` cop which added in the rubocop version `0.88`.
 
 ## 0.9.0 (2020-05-27)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     datarockets-style (0.9.0)
-      rubocop (~> 0.84)
-      rubocop-rails (>= 2.5.2, < 2.7.0)
-      rubocop-rspec (~> 1.39)
+      rubocop (~> 0.88)
+      rubocop-rails (>= 2.6.0, < 2.7.0)
+      rubocop-rspec (~> 1.42)
 
 GEM
   remote: https://rubygems.org/

--- a/config/base.yml
+++ b/config/base.yml
@@ -57,6 +57,9 @@ Layout/SpaceInsideHashLiteralBraces:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
@@ -75,7 +78,13 @@ Naming/RescuedExceptionsVariableName:
 Style/AccessorGrouping:
   Enabled: true
 
+Style/ArrayCoercion:
+  Enabled: true
+
 Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/CaseLikeIf:
   Enabled: true
 
 Style/ClassAndModuleChildren:
@@ -87,8 +96,15 @@ Style/EmptyMethod:
 Style/ExponentialNotation:
   Enabled: true
 
+Style/HashAsLastArrayItem:
+  Enabled: true
+  EnforcedStyle: no_braces
+
 Style/HashEachMethods:
   Enabled: true
+
+Style/HashLikeCase:
+   Enabled: true
 
 Style/HashTransformKeys:
   Enabled: true
@@ -106,6 +122,9 @@ Style/RedundantAssignment:
   Enabled: true
 
 Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
   Enabled: true
 
 Style/RedundantRegexpCharacterClass:

--- a/datarockets-style.gemspec
+++ b/datarockets-style.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.84"
-  spec.add_dependency "rubocop-rails", ">= 2.5.2", "< 2.7.0"
-  spec.add_dependency "rubocop-rspec", "~> 1.39"
+  spec.add_dependency "rubocop", "~> 0.88"
+  spec.add_dependency "rubocop-rails", ">= 2.6.0", "< 2.7.0"
+  spec.add_dependency "rubocop-rspec", "~> 1.42"
 end


### PR DESCRIPTION
This PRs update rubocop to 0.88. Left all cops by default but changed only this cop https://docs.rubocop.org/rubocop/cops_style.html#stylehashaslastarrayitem

Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [x] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
