### PR TITLE
Revert "fix release version in changelog"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## master
 
-## 1.1.0 (2021-02-04)
+## 1.0.1 (2021-02-04)
 
 ### Added
 


### PR DESCRIPTION
Reverts datarockets/datarockets-style#241

@paydaylight I'll revert this PR cause I'm absolutely diagredd this versions '1.0.1' the next reason:

1) We have rules about naming the releases https://github.com/datarockets/datarockets-style/blob/master/RELEASING.md . So you can see that any changes, which update dependencies, also changes minor version (not patch version) 

Also in this document, we have a check list which we're doing on release https://github.com/datarockets/datarockets-style/blob/master/RELEASING.md and some steps are missed

- Update version.rb file accordingly.
- ~Update CHANGELOG.md file.~
- Update Gemfile.lock file via running bundle install.
- Build and publish (and verify that everything ok):
- Tag the release: git tag vVERSION.
- ~Push changes: git push --tags.~
- Update the release notes on GitHub.com. (Format is incorrect. Check pls release notes before) 
- Announce the new release, making sure to say "thank you" to the contributors who helped shape this version!