### PR TITLE
[Fix #233] Add more trailing comma rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 ## Changed
 
 * Change ```Datarockets::Style``` module to ```DatarocketsStyle``` ([@paydaylight](https://github.com/paydaylight))
-* Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight](https://github.com/paydaylight))
+* [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight](https://github.com/paydaylight))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## master
 
+### Changed
+
 * [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight][])
 
 ## 1.1.0 (2021-02-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 ## Changed
 
 * Change ```Datarockets::Style``` module to ```DatarocketsStyle``` ([@paydaylight](https://github.com/paydaylight))
-* [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight](https://github.com/paydaylight))
+* [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight][])
 
 ### Fixed
 
@@ -228,4 +228,3 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 [@v.kuzmik]: https://github.com/TheBlackArroVV/
 [@a.branzeanu]: https://github.com/texpert
 [@nikitasakov]: https://github.com/nikitasakov
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 ## Changed
 
 * Change ```Datarockets::Style``` module to ```DatarocketsStyle``` ([@paydaylight](https://github.com/paydaylight))
+* Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight](https://github.com/paydaylight))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## master
 
-## 1.1.0 (2021-02-09)
-
 * [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight][])
 
 ## 1.1.0 (2021-02-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,21 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## Changed
 
-* Change ```Datarockets::Style``` module to ```DatarocketsStyle``` ([@paydaylight](https://github.com/paydaylight))
 * [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight][])
 
-### Fixed
-
-* [#177](https://github.com/datarockets/datarockets-style/issues/177) set ```Layout/MultilineOperationIndentation``` to indented ([@paydaylight](https://github.com/paydaylight))
-
-## 1.0.1 (2021-02-04)
-
-### Added
-
-* Add ```.idea``` to .gitignore ([@paydaylight](https://github.com/paydaylight))
+## 1.1.0 (2021-02-09)
 
 ### Changed
 
 * Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInHashLiteral` rule. ([@r.dubrovsky][])
-* Update rubocop to ```1.9.1``` ([@paydaylight](https://github.com/paydaylight))
-* Update rubocop-rails requirement to ```>= 2.8.0, < 2.10.0``` ([@paydaylight](https://github.com/paydaylight))
+* Update rubocop to `1.9.1`. ([@paydaylight][])
+* Update rubocop-rails requirement to `>= 2.8.0, < 2.10.0`. ([@paydaylight][])
+* Update rubocop-rspec to `2.2.0`. ([@paydaylight][])
+* Change `Datarockets::Style` module to `DatarocketsStyle`. ([@paydaylight][])
+
+### Fixed
+
+* [#177](https://github.com/datarockets/datarockets-style/issues/177) set `Layout/MultilineOperationIndentation` to indented ([@paydaylight][])
 
 ## 1.0.0 (2020-11-10)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datarockets-style (1.0.0)
+    datarockets-style (1.1.0)
       rubocop (>= 1.2, < 2.0)
       rubocop-rails (>= 2.8.0, < 2.10.0)
       rubocop-rspec (~> 2.0)
@@ -9,17 +9,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.4)
+    activesupport (6.1.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
-    i18n (1.8.7)
+    i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.14.3)
@@ -65,14 +66,14 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.90.0, < 2.0)
-    rubocop-rspec (2.1.0)
+    rubocop-rspec (2.2.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/config/base.yml
+++ b/config/base.yml
@@ -190,5 +190,11 @@ Style/StringConcatenation:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma

--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -392,6 +392,86 @@ def foo
 end
 ```
 
+* <a name="style-trailing-comma-in-arguments"></a>
+  Requires a comma after the last argument, but only for parenthesized method calls where each argument is on its own line.
+  <sup>[[link](#style-trailing-comma-in-arguments)]</sup>
+
+```ruby
+# bad
+method(1, 2,)
+
+# good
+method(1, 2)
+
+# bad
+method(
+  1, 2,
+  3,
+)
+
+# good
+method(
+  1, 2,
+  3
+)
+
+# bad
+method(
+  1, 2, 3,
+)
+
+# good
+method(
+  1, 2, 3
+)
+
+# good
+method(
+  1,
+  2,
+)
+```
+
+* <a name="style-trailing-comma-in-array-literals"></a>
+  Requires a comma after last item in an array, but only when each item is on its own line.
+  <sup>[[link](#style-trailing-comma-in-array-literals)]</sup>
+
+```ruby
+# bad
+a = [1, 2,]
+
+# good
+a = [1, 2]
+
+# bad
+a = [
+  1, 2,
+  3,
+]
+
+# good
+a = [
+  1, 2,
+  3
+]
+
+# bad
+a = [
+  1, 2, 3,
+]
+
+# good
+a = [
+  1, 2, 3
+]
+
+# good
+a = [
+  1,
+  2,
+]
+```
+
 * <a name="style-trailing-comma-in-hash-literal"></a>
   Requires a comma after the last item in a hash.
   <sup>[[link](#style-trailing-comma-in-hash-literal)]</sup>

--- a/lib/datarockets_style/version.rb
+++ b/lib/datarockets_style/version.rb
@@ -1,3 +1,3 @@
 module DatarocketsStyle
-  VERSION = "1.0.0".freeze
+  VERSION = "1.1.0".freeze
 end

--- a/spec/datarockets_style/cop/layout/array_alignment_extended_spec.rb
+++ b/spec/datarockets_style/cop/layout/array_alignment_extended_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DatarocketsStyle::Cop::Layout::ArrayAlignmentExtended, skip: true
       },
       "Layout/IndentationWidth" => {
         "Width" => 2,
-      }
+      },
     )
   end
 

--- a/spec/datarockets_style/formatter/todo_list_formatter/report_summary_spec.rb
+++ b/spec/datarockets_style/formatter/todo_list_formatter/report_summary_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DatarocketsStyle::Formatter::TodoListFormatter::ReportSummary do
       TodoListFormatter::FileOffence.new("test1.rb", "CopC"),
       TodoListFormatter::FileOffence.new("test2.rb", "CopA"),
       TodoListFormatter::FileOffence.new("test3.rb", "CopB"),
-      TodoListFormatter::FileOffence.new("test3.rb", "CopB")
+      TodoListFormatter::FileOffence.new("test3.rb", "CopB"),
     ].shuffle
   end
 

--- a/spec/datarockets_style/formatter/todo_list_formatter_spec.rb
+++ b/spec/datarockets_style/formatter/todo_list_formatter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe TodoListFormatter do
               Parser::Source::Range.new(source_buffer, 0, 1),
               "message",
               cop_name,
-              corrected_cops.include?(cop_name) ? :corrected : :uncorrected
+              corrected_cops.include?(cop_name) ? :corrected : :uncorrected,
             )
           end
           formatter.file_finished(file, offenses)


### PR DESCRIPTION
### Added more trailing comma cops as in [#218](https://github.com/datarockets/datarockets-style/issues/218):
* Added `EnforcedStyleForMultiline: comma`  for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral`.
* Did not enable `Style/TrailingCommaInBlockArgs` because of safety warnings and unsure usage purpose


Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [x] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
