### PR TITLE
Return gemfile.lock to prev state

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datarockets-style (1.0.0)
+    datarockets-style (1.1.0)
       rubocop (>= 1.2, < 2.0)
       rubocop-rails (>= 2.8.0, < 2.10.0)
       rubocop-rspec (~> 2.0)
@@ -9,17 +9,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.4)
+    activesupport (6.1.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
-    i18n (1.8.7)
+    i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.14.3)
@@ -65,14 +66,14 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.90.0, < 2.0)
-    rubocop-rspec (2.1.0)
+    rubocop-rspec (2.2.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Return `Gemfile.lock` to what it was before in master. This is needed to resolve merge conflict in [#247](https://github.com/datarockets/datarockets-style/pull/247) (`Gemfile.lock` was deleted in that PR but modified in the latest PR merge).

Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [ ] verified that cops are ordered by alphabet
- [ ] add a note to the style guide docs (if it needs)
- [ ] add a note to the changelog file
- [ ] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
