### PR TITLE
[Fix #251] Update readme to match release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 * [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight][])
 * [#124](https://github.com/datarockets/datarockets-style/issues/124) Move gem dependencies to `./datarockets-style.gemspec` and drop `Gemfile.lock` tracking. ([@paydaylight][])
 
+### Fixed
+
+* [#251](https://github.com/datarockets/datarockets-style/issues/251) Update documentation to match `1.1.0` release changes. ([@paydaylight][])
+
 ## 1.1.0 (2021-02-09)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Add this line to your application's Gemfile:
 
 ```ruby
 group :test, :development do
-  gem 'datarockets-style', '~> 1.0.0'
+  gem 'datarockets-style', '~> 1.1.0'
 end
 ```
 
 Or, for a Ruby library, add this to your gemspec:
 
 ```ruby
-spec.add_development_dependency 'datarockets-style', '~> 1.0.0'
+spec.add_development_dependency 'datarockets-style', '~> 1.1.0'
 ```
 
 And then execute:
@@ -108,28 +108,28 @@ Result of the formatter is compatible with rubocop config or rubocop todo file.
 For running that cop, just print in your command like
 
 ```bash
-$ bundle exec rubocop -f TodoListFormatter -r datarockets/style
+$ bundle exec rubocop -f TodoListFormatter -r datarockets_style
 Inspecting 10 files
 ...CC.CC..
 10 files inspected, 7 offenses detected
 
 Layout/IndentationConsistency:
   Exclude:
-    - 'spec/datarockets/style/formatter/todo_list_formatter_spec.rb' # 1
+    - 'spec/datarockets_style/formatter/todo_list_formatter_spec.rb' # 1
 
 Naming/MemoizedInstanceVariableName:
   Exclude:
-    - 'lib/datarockets/style/formatter/todo_list_formatter/report_summary.rb' # 1
+    - 'lib/datarockets_style/formatter/todo_list_formatter/report_summary.rb' # 1
 
 RSpec/ExampleLength:
   Exclude:
-    - 'spec/datarockets/style/formatter/todo_list_formatter/report_summary_spec.rb' # 1
-    - 'spec/datarockets/style/formatter/todo_list_formatter_spec.rb' # 2
+    - 'spec/datarockets_style/formatter/todo_list_formatter/report_summary_spec.rb' # 1
+    - 'spec/datarockets_style/formatter/todo_list_formatter_spec.rb' # 2
 
 Style/Documentation:
   Exclude:
-    - 'lib/datarockets/style/formatter/todo_list_formatter/report_summary.rb' # 1
-    - 'lib/datarockets/style/formatter/todo_list_formatter.rb' # 1
+    - 'lib/datarockets_style/formatter/todo_list_formatter/report_summary.rb' # 1
+    - 'lib/datarockets_style/formatter/todo_list_formatter.rb' # 1
 ```
 
 #### Autocorrection
@@ -137,24 +137,24 @@ Style/Documentation:
 If you run the formatter with autocorrection options, the formatter skip corrected cop and does not include it to the result.
 
 ```bash
-$ bundle exec rubocop -f TodoListFormatter -r datarockets/style -a
+$ bundle exec rubocop -f TodoListFormatter -r datarockets_style -a
 Inspecting 10 files
 ...CC.CC..
 10 files inspected, 7 offenses detected, 1 offenses corrected
 
 Naming/MemoizedInstanceVariableName:
   Exclude:
-    - 'lib/datarockets/style/formatter/todo_list_formatter/report_summary.rb' # 1
+    - 'lib/datarockets_style/formatter/todo_list_formatter/report_summary.rb' # 1
 
 RSpec/ExampleLength:
   Exclude:
-    - 'spec/datarockets/style/formatter/todo_list_formatter/report_summary_spec.rb' # 1
-    - 'spec/datarockets/style/formatter/todo_list_formatter_spec.rb' # 2
+    - 'spec/datarockets_style/formatter/todo_list_formatter/report_summary_spec.rb' # 1
+    - 'spec/datarockets_style/formatter/todo_list_formatter_spec.rb' # 2
 
 Style/Documentation:
   Exclude:
-    - 'lib/datarockets/style/formatter/todo_list_formatter/report_summary.rb' # 1
-    - 'lib/datarockets/style/formatter/todo_list_formatter.rb' # 1
+    - 'lib/datarockets_style/formatter/todo_list_formatter/report_summary.rb' # 1
+    - 'lib/datarockets_style/formatter/todo_list_formatter.rb' # 1
 ```
 
 ## Non-goals of RuboCop
@@ -178,4 +178,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Datarockets::Style project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](CODE_OF_CONDUCT.md).
+Everyone interacting in the DatarocketsStyle project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
### Updated readme after releasing 1.1.0

* Fixed `--require` cli flag to target new module path.
* Fixed `TodoListFormatter` output to match the new module path.
* Bumped gem's version.

Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [ ] verified that cops are ordered by alphabet
- [ ] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
