### PR TITLE
[Fix #124] Specify strict version of rubocop-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 * [#233](https://github.com/datarockets/datarockets-style/issues/233) Setup `EnforcedStyleForMultiline` for `Style/TrailingCommaInArguments` and `Style/TrailingCommaInArrayLiteral` rules. ([@paydaylight][])
 * [#124](https://github.com/datarockets/datarockets-style/issues/124) Move gem dependencies to `./datarockets-style.gemspec` and drop `Gemfile.lock` tracking. ([@paydaylight][])
 * [#253](https://github.com/datarockets/datarockets-style/issues/253) Update rubocop to `1.10`. ([@paydaylight][])
+* [#124](https://github.com/datarockets/datarockets-style/issues/124) Update rubocop-rails to `2.9`. ([@paydaylight][])
 
 ### Fixed
 

--- a/datarockets-style.gemspec
+++ b/datarockets-style.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 1.10"
-  spec.add_dependency "rubocop-rails", ">= 2.8.0", "< 2.10.0"
+  spec.add_dependency "rubocop-rails", "~> 2.9"
   spec.add_dependency "rubocop-rspec", "~> 2.0"
 
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Set rubocop-rails's version to a latest minor release (2.9)

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [ ] verified that cops are ordered by alphabet
- [ ] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [ ] squash all commits before submitting to review
