### PR TITLE
Change required ruby version after upgrading rubocop-graphql

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.0'
         bundler-cache: true
 
     - name: Run linter

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # for checking cops with interpolation
 Lint/InterpolationCheck:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 
 ## master
 
+## 1.6.0 (2024-08-26)
+
+### Changed
+
+* **(Breaking)** Support Ruby >= 3.0.0
+
 ## 1.5.0 (2023-09-11)
 
 ### Added

--- a/datarockets-style.gemspec
+++ b/datarockets-style.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/datarockets/datarockets-style"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
Currently checks are failed on current version. It's appeared after upgrading `rubocop-graphql` in https://github.com/datarockets/ruby-style/commit/cbc6697393240aa97099ffcd4631bf4bc43147fb to rubocop-graphql >= 1.2.0 which depends on Ruby >= 3.0.

Before you submit a pull request, please make sure you have to follow:

- [x] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [x] add a description of the problem you're trying to solve (short summary from related issue)
- [x] verified that cops are ordered by alphabet
- [x] add a note to the style guide docs (if it needs)
- [x] add a note to the changelog file
- [x] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [x] squash all commits before submitting to review
